### PR TITLE
Add offline HTTP client helper project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+offline-http-client/dist/

--- a/offline-http-client/README.md
+++ b/offline-http-client/README.md
@@ -1,0 +1,118 @@
+# Offline HTTP Client
+
+An Observable-inspired HTTP helper that transparently queues network requests in IndexedDB when offline and replays them once the device regains connectivity. Designed for field applications where work is performed offline during the day and synchronised when workers return online.
+
+## Features
+
+- 📡 Observable-style API (`client.request(...).subscribe(...)`) with helpers for common HTTP verbs.
+- 📦 Automatic persistence of queued requests in IndexedDB, including JSON payloads, file uploads, and form data.
+- 🔁 Configurable retry strategies (exponential, linear, fixed) with back-off and event notifications.
+- 🧩 Event-driven lifecycle: consumers subscribe to `queue:added`, `sync:success`, `sync:error`, `sync:retry`, `sync:failed`, and `queue:drain` to update UI or trigger compensating flows.
+- 🧾 Persisted event log so applications can recover state after restarts and surface historical sync errors to users.
+- ♻️ Manual recovery APIs for inspecting pending/failed requests and re-queuing failures.
+
+## Installation
+
+```bash
+npm install offline-http-client
+```
+
+The package ships ESM output (`dist/`) and TypeScript declarations.
+
+## Quick start
+
+```ts
+import { OfflineHttpClient } from 'offline-http-client';
+
+const client = new OfflineHttpClient({
+  defaultRetries: 5,
+  defaultRetryDelay: 2000,
+});
+
+client.events.on('sync:error', ({ detail }) => {
+  // Persist to UI state, notify the user, etc.
+  console.error('Sync failed', detail);
+});
+
+client
+  .post('https://api.example.com/work-logs', {
+    entries: [{ id: 'task-1', status: 'done' }],
+  })
+  .subscribe({
+    next: (result) => {
+      if (result.status === 'queued') {
+        console.log('Saved offline with id', result.id);
+      } else {
+        console.log('Server acknowledged', result.data);
+      }
+    },
+    error: (err) => console.error('Immediate failure', err),
+  });
+```
+
+### Handling files and form data
+
+```ts
+const formData = new FormData();
+formData.append('metadata', JSON.stringify({ siteId: 'A12' }));
+formData.append('photo', fileInput.files[0]);
+
+client.post('https://api.example.com/uploads', formData, {
+  responseType: 'json',
+});
+```
+
+Binary payloads are stored as `Blob`s inside IndexedDB to avoid lossy serialisation.
+
+### Recovering from sync failures
+
+```ts
+const failed = await client.getFailedRequests();
+// Show failed items in the UI and allow users to retry selected ones
+await client.retryFailed(failed.map((req) => req.id));
+```
+
+The event log is persisted so applications reopening later can inspect prior sync attempts:
+
+```ts
+const events = await client.getEventHistory();
+for (const event of events) {
+  // Render event.detail to give operators context about what happened.
+}
+```
+
+## Event reference
+
+| Event            | Payload summary |
+| ---------------- | --------------- |
+| `queue:added`    | Request persisted offline. |
+| `sync:success`   | Request replayed successfully with parsed response payload. |
+| `sync:error`     | Sync failed (network or HTTP) and may retry. |
+| `sync:retry`     | Retry scheduled with delay in milliseconds. |
+| `sync:failed`    | Terminal failure (HTTP non-OK or retries exhausted). |
+| `queue:drain`    | Queue processing completed with `remaining` count. |
+
+> ⚠️ Errors are **always** surfaced via events so that applications reopened later can reconstruct state. Observers attached to the original request receive `error` notifications only for immediate, online failures.
+
+## Offline workflow
+
+1. When the device is offline (determined via `navigator.onLine`) requests are serialised and stored in IndexedDB.
+2. Each stored request tracks retry metadata (strategy, attempt count, last error, metadata).
+3. The client listens for the browser `online` event and resumes processing. Requests are replayed oldest-first.
+4. Responses are parsed according to the original `responseType`, persisted to the event log, and surfaced to listeners.
+5. Failures trigger retries using the selected strategy. Once retry attempts are exhausted, the request remains flagged as `failed` for manual recovery.
+
+Refer to [`docs/architecture.md`](docs/architecture.md) for diagrams of the data flow and offline/online state machine.
+
+## Building from source
+
+```bash
+npm install
+npm run build
+```
+
+The build emits ESM into `dist/` with accompanying `.d.ts` files.
+
+## License
+
+MIT

--- a/offline-http-client/docs/architecture.md
+++ b/offline-http-client/docs/architecture.md
@@ -1,0 +1,91 @@
+# Architecture Overview
+
+## High-level components
+
+```mermaid
+graph TD
+  A[Application code] -- subscribes --> B[OfflineHttpClient]
+  B -- emits --> C[SyncEventBus]
+  B -- persists --> D[(IndexedDB: requests store)]
+  B -- logs --> E[(IndexedDB: events store)]
+  B -- uses --> F[Observable]
+  B -- serialises --> G[Serialization helpers]
+  D -.replay queue.-> H[Fetch API]
+  H --> A
+  E -.historical events.-> A
+```
+
+## Offline to online flow
+
+```mermaid
+stateDiagram-v2
+  [*] --> Online
+  Online --> Offline: navigator.onLine === false
+  Offline --> Queueing: request()
+  Queueing --> Offline: stored in IndexedDB
+  Offline --> Online: network restored
+  Online --> Replaying: processQueue()
+  Replaying --> Success: fetch ok
+  Replaying --> Retry: network error
+  Retry --> Replaying: backoff elapsed
+  Retry --> Failed: attempts exhausted
+  Success --> Online
+  Failed --> Online
+```
+
+## Sequence: offline request replay
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant Client as OfflineHttpClient
+  participant DB as IndexedDB
+  participant Events as SyncEventBus
+  participant Net as Fetch API
+
+  App->>Client: request(method, url, options)
+  alt navigator offline or queueOnly
+    Client->>DB: saveRequest(request)
+    Client->>Events: queue:added(detail)
+    Events-->>App: queue:added
+  else online
+    Client->>Net: fetch(url, init)
+    Net-->>Client: Response / Error
+    opt error
+      Client->>DB: saveRequest(request)
+      Client->>Events: sync:error(detail)
+    end
+  end
+  par when online
+    Client->>DB: list pending
+    loop each request
+      Client->>Net: fetch(url, init)
+      alt success
+        Net-->>Client: Response
+        Client->>Events: sync:success(detail)
+        Client->>DB: deleteRequest(id)
+      else failure with retries left
+        Net-->>Client: Error
+        Client->>Events: sync:error(detail)
+        Client->>Events: sync:retry(delay)
+        Client->>DB: updateRequest(state=pending)
+      else failure terminal
+        Net-->>Client: Error/HTTP !ok
+        Client->>Events: sync:failed(detail)
+        Client->>DB: updateRequest(state=failed)
+      end
+    end
+    Client->>Events: queue:drain(remaining)
+  end
+```
+
+## Data persistence
+
+- **Requests store**: `StoredRequest` records containing HTTP method, URL, serialised body, headers, metadata, retry policy, attempt counters, timestamps, and last error.
+- **Events store**: chronological event log for auditability and UI reconstruction. Each event stores the payload dispatched through the runtime event bus.
+
+## Error surface and recovery
+
+- Immediate online errors surface to the request observable *and* `sync:error` events (with `willRetry = false`).
+- Offline/queued errors surface through events only, ensuring UIs reopened later can rehydrate context.
+- Failed requests remain in IndexedDB with `state = failed`. Applications can inspect them via `getFailedRequests()` and resubmit by calling `retryFailed([...ids])`.

--- a/offline-http-client/package-lock.json
+++ b/offline-http-client/package-lock.json
@@ -1,0 +1,246 @@
+{
+  "name": "offline-http-client",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "offline-http-client",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "idb": "^8.0.3"
+      },
+      "devDependencies": {
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/offline-http-client/package.json
+++ b/offline-http-client/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "offline-http-client",
+  "version": "1.0.0",
+  "description": "Observable-style HTTP helper with offline IndexedDB queueing and sync events",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "prepare": "npm run build",
+    "test": "npm run build"
+  },
+  "keywords": [
+    "http",
+    "offline",
+    "indexeddb",
+    "observable",
+    "sync"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "idb": "^8.0.3"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2"
+  }
+}

--- a/offline-http-client/src/events.ts
+++ b/offline-http-client/src/events.ts
@@ -1,0 +1,42 @@
+import type { SyncEventMap, SyncEventRecord, SyncEventType } from './types.js';
+
+export type SyncEventListener<T extends SyncEventType> = (event: CustomEvent<SyncEventMap[T]>) => void;
+
+export class SyncEventBus {
+  private readonly target = new EventTarget();
+
+  on<T extends SyncEventType>(type: T, listener: SyncEventListener<T>, options?: AddEventListenerOptions): void {
+    this.target.addEventListener(type, listener as EventListener, options);
+  }
+
+  off<T extends SyncEventType>(type: T, listener: SyncEventListener<T>, options?: EventListenerOptions): void {
+    this.target.removeEventListener(type, listener as EventListener, options);
+  }
+
+  once<T extends SyncEventType>(type: T, listener: SyncEventListener<T>): void {
+    const wrapper: SyncEventListener<T> = ((event: CustomEvent<SyncEventMap[T]>) => {
+      this.off(type, wrapper);
+      listener(event);
+    }) as SyncEventListener<T>;
+    this.on(type, wrapper);
+  }
+
+  emit<T extends SyncEventType>(type: T, detail: SyncEventMap[T]): SyncEventRecord<T> {
+    const record: SyncEventRecord<T> = {
+      id: generateId(),
+      type,
+      detail,
+      timestamp: Date.now(),
+    };
+    const event = new CustomEvent(type, { detail });
+    this.target.dispatchEvent(event);
+    return record;
+  }
+}
+
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}

--- a/offline-http-client/src/httpClient.ts
+++ b/offline-http-client/src/httpClient.ts
@@ -1,0 +1,482 @@
+import { Observable } from './observable.js';
+import type { Observer } from './observable.js';
+import { SyncEventBus } from './events.js';
+import type {
+  HttpMethod,
+  HttpRequestOptions,
+  HttpResult,
+  HttpSuccessResult,
+  HttpQueuedResult,
+  OfflineHttpClientOptions,
+  ResponseType,
+  StoredRequest,
+  SyncErrorEventDetail,
+  SyncEventRecord,
+  SyncQueueEventDetail,
+  SyncRetryEventDetail,
+  SyncSuccessEventDetail,
+  SerializedBody,
+} from './types.js';
+import {
+  initDatabase,
+  saveRequest,
+  deleteRequest,
+  listRequestsByState,
+  updateRequest,
+  saveEvent,
+  getEventLog,
+  pruneEvents,
+  migrateFailedToPending,
+} from './storage.js';
+import type { OfflineHttpDatabase } from './storage.js';
+import { serializeBody, deserializeBody } from './serialization.js';
+
+const DEFAULT_RETRIES = 3;
+const DEFAULT_RETRY_DELAY = 2000;
+const DEFAULT_RESPONSE_TYPE: ResponseType = 'json';
+
+export class OfflineHttpClient {
+  private readonly dbPromise: Promise<OfflineHttpDatabase>;
+  private readonly options: Required<Pick<OfflineHttpClientOptions, 'defaultRetries' | 'defaultRetryDelay' | 'queueRetentionMs' | 'autoStart'>>;
+  private readonly requestStoreName: string;
+  private readonly eventStoreName: string;
+  private processing = false;
+  private started = false;
+  private onlineListener?: () => void;
+
+  readonly events = new SyncEventBus();
+
+  constructor(options: OfflineHttpClientOptions = {}) {
+    this.options = {
+      defaultRetries: options.defaultRetries ?? DEFAULT_RETRIES,
+      defaultRetryDelay: options.defaultRetryDelay ?? DEFAULT_RETRY_DELAY,
+      queueRetentionMs: options.queueRetentionMs ?? 1000 * 60 * 60 * 24 * 7,
+      autoStart: options.autoStart ?? true,
+    };
+    this.requestStoreName = options.storeName ?? 'requests';
+    this.eventStoreName = options.eventStoreName ?? 'events';
+    this.dbPromise = initDatabase(options);
+
+    if (this.options.autoStart) {
+      void this.start();
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    await this.dbPromise;
+    if (typeof window !== 'undefined') {
+      this.onlineListener = () => {
+        if (this.isOnline()) {
+          void this.processQueue();
+        }
+      };
+      window.addEventListener('online', this.onlineListener);
+    }
+    if (this.isOnline()) {
+      await this.processQueue();
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.started) return;
+    this.started = false;
+    if (typeof window !== 'undefined' && this.onlineListener) {
+      window.removeEventListener('online', this.onlineListener);
+    }
+  }
+
+  request<T = unknown>(method: HttpMethod, url: string, options: HttpRequestOptions = {}): Observable<HttpResult<T>> {
+    return new Observable<HttpResult<T>>((observer) => {
+      void this.handleRequest(method, url, options, observer).catch((error) => {
+        observer.error(error);
+      });
+    });
+  }
+
+  get<T = unknown>(url: string, options?: HttpRequestOptions): Observable<HttpResult<T>> {
+    return this.request<T>('GET', url, options);
+  }
+
+  post<T = unknown>(url: string, body?: unknown, options: HttpRequestOptions = {}): Observable<HttpResult<T>> {
+    return this.request<T>('POST', url, { ...options, body });
+  }
+
+  put<T = unknown>(url: string, body?: unknown, options: HttpRequestOptions = {}): Observable<HttpResult<T>> {
+    return this.request<T>('PUT', url, { ...options, body });
+  }
+
+  patch<T = unknown>(url: string, body?: unknown, options: HttpRequestOptions = {}): Observable<HttpResult<T>> {
+    return this.request<T>('PATCH', url, { ...options, body });
+  }
+
+  delete<T = unknown>(url: string, options?: HttpRequestOptions): Observable<HttpResult<T>> {
+    return this.request<T>('DELETE', url, options);
+  }
+
+  head<T = unknown>(url: string, options?: HttpRequestOptions): Observable<HttpResult<T>> {
+    return this.request<T>('HEAD', url, options);
+  }
+
+  async getPendingRequests(): Promise<StoredRequest[]> {
+    const db = await this.dbPromise;
+    return listRequestsByState(db, this.requestStoreName, 'pending');
+  }
+
+  async getFailedRequests(): Promise<StoredRequest[]> {
+    const db = await this.dbPromise;
+    return listRequestsByState(db, this.requestStoreName, 'failed');
+  }
+
+  async retryFailed(ids?: string[]): Promise<void> {
+    const db = await this.dbPromise;
+    const failed = await this.getFailedRequests();
+    const retryIds = ids?.length ? failed.filter((req) => ids.includes(req.id)).map((req) => req.id) : failed.map((req) => req.id);
+    if (!retryIds.length) return;
+    await migrateFailedToPending(db, this.requestStoreName, retryIds);
+    if (this.isOnline()) {
+      await this.processQueue();
+    }
+  }
+
+  async getEventHistory(since?: number): Promise<SyncEventRecord[]> {
+    const db = await this.dbPromise;
+    return getEventLog(db, this.eventStoreName, since);
+  }
+
+  private async handleRequest<T>(
+    method: HttpMethod,
+    url: string,
+    options: HttpRequestOptions,
+    observer: Observer<HttpResult<T>>,
+  ): Promise<void> {
+    const responseType = options.responseType ?? DEFAULT_RESPONSE_TYPE;
+    const serializedBody = serializeBody(options.body);
+    const headers = new Headers(options.headers ?? {});
+    applyDefaultContentType(headers, serializedBody);
+
+    const requestRecord: StoredRequest = {
+      id: generateId(),
+      method,
+      url,
+      headers: Array.from(headers.entries()),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      attempts: 0,
+      maxAttempts: Math.max(1, options.retries ?? this.options.defaultRetries),
+      retryDelay: options.retryDelay ?? this.options.defaultRetryDelay,
+      retryStrategy: options.retryStrategy ?? 'exponential',
+      responseType,
+      state: 'pending',
+    };
+
+    if (serializedBody) {
+      requestRecord.body = serializedBody;
+    }
+    if (options.metadata) {
+      requestRecord.metadata = options.metadata;
+    }
+
+    const online = this.isOnline() && !options.queueOnly;
+    const db = await this.dbPromise;
+
+    if (!online) {
+      await this.enqueueRequest(db, requestRecord, observer);
+      return;
+    }
+
+    try {
+      const fetchInit = buildFetchInit(requestRecord, options.signal);
+      const response = await fetch(url, fetchInit);
+      if (!response.ok) {
+        const error = new Error(`HTTP error ${response.status}`);
+        const detail = toErrorDetail(requestRecord, error, false);
+        const record = this.events.emit('sync:error', detail);
+        await saveEvent(db, this.eventStoreName, record);
+        observer.error(error);
+        return;
+      }
+      const data = (await parseResponse<T>(response.clone(), responseType)) as T;
+      const result: HttpSuccessResult<T> = {
+        status: 'success',
+        response,
+        data,
+      };
+      observer.next(result);
+      observer.complete();
+    } catch (error) {
+      requestRecord.lastError = error instanceof Error ? error.message : String(error);
+      await this.enqueueRequest(db, requestRecord, observer, error);
+    }
+  }
+
+  private async enqueueRequest<T>(
+    db: OfflineHttpDatabase,
+    requestRecord: StoredRequest,
+    observer: Observer<HttpResult<T>>,
+    error?: unknown,
+  ): Promise<void> {
+    await saveRequest(db, this.requestStoreName, requestRecord);
+    const queueEvent: SyncQueueEventDetail = {
+      id: requestRecord.id,
+      url: requestRecord.url,
+      method: requestRecord.method,
+      ...(requestRecord.metadata ? { metadata: requestRecord.metadata } : {}),
+    };
+    const record = this.events.emit('queue:added', queueEvent);
+    await saveEvent(db, this.eventStoreName, record);
+
+    if (error) {
+      const detail = toErrorDetail(requestRecord, error, true);
+      const errorRecord = this.events.emit('sync:error', detail);
+      await saveEvent(db, this.eventStoreName, errorRecord);
+    }
+
+    const result: HttpQueuedResult = {
+      status: 'queued',
+      id: requestRecord.id,
+    };
+    if (requestRecord.metadata) {
+      result.metadata = requestRecord.metadata;
+    }
+    observer.next(result);
+    observer.complete();
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processing) return;
+    this.processing = true;
+
+    try {
+      const db = await this.dbPromise;
+      const pending = await listRequestsByState(db, this.requestStoreName, 'pending');
+      pending.sort((a, b) => a.createdAt - b.createdAt);
+
+      for (const request of pending) {
+        if (!this.isOnline()) {
+          break;
+        }
+        await this.executeQueuedRequest(db, request);
+      }
+
+      const remaining = await listRequestsByState(db, this.requestStoreName, 'pending');
+      const drainRecord = this.events.emit('queue:drain', { remaining: remaining.length });
+      await saveEvent(db, this.eventStoreName, drainRecord);
+
+      await pruneEvents(db, this.eventStoreName, this.options.queueRetentionMs);
+    } finally {
+      this.processing = false;
+    }
+  }
+
+  private async executeQueuedRequest(db: OfflineHttpDatabase, request: StoredRequest): Promise<void> {
+    const updated: StoredRequest = { ...request, state: 'processing', attempts: request.attempts + 1, updatedAt: Date.now() };
+    await updateRequest(db, this.requestStoreName, updated);
+
+    try {
+      const response = await fetch(updated.url, buildFetchInit(updated));
+      if (!response.ok) {
+        const error = new Error(`HTTP error ${response.status}`);
+        await this.handlePermanentFailure(db, updated, error);
+        return;
+      }
+
+      const data = await parseResponse(response.clone(), updated.responseType);
+      const successDetail: SyncSuccessEventDetail = {
+        id: updated.id,
+        url: updated.url,
+        method: updated.method,
+        response: {
+          status: response.status,
+          ok: response.ok,
+          headers: Array.from(response.headers.entries()),
+          data,
+        },
+        ...(updated.metadata ? { metadata: updated.metadata } : {}),
+      };
+
+      await deleteRequest(db, this.requestStoreName, updated.id);
+      const record = this.events.emit('sync:success', successDetail);
+      await saveEvent(db, this.eventStoreName, record);
+    } catch (error) {
+      await this.handleRetryableFailure(db, updated, error);
+    }
+  }
+
+  private async handleRetryableFailure(
+    db: OfflineHttpDatabase,
+    request: StoredRequest,
+    error: unknown,
+  ): Promise<void> {
+    const willRetry = request.attempts < request.maxAttempts;
+    const detail = toErrorDetail(request, error, willRetry);
+    const record = this.events.emit(willRetry ? 'sync:error' : 'sync:failed', detail);
+    await saveEvent(db, this.eventStoreName, record);
+
+    if (!willRetry) {
+      request.state = 'failed';
+      request.lastError = detail.error;
+      request.updatedAt = Date.now();
+      await updateRequest(db, this.requestStoreName, request);
+      return;
+    }
+
+    const nextDelay = computeRetryDelay(request);
+    const retryDetail: SyncRetryEventDetail = {
+      id: request.id,
+      url: request.url,
+      method: request.method,
+      attempt: request.attempts,
+      nextRetryInMs: nextDelay,
+      ...(request.metadata ? { metadata: request.metadata } : {}),
+    };
+    const retryRecord = this.events.emit('sync:retry', retryDetail);
+    await saveEvent(db, this.eventStoreName, retryRecord);
+
+    request.state = 'pending';
+    request.updatedAt = Date.now();
+    request.lastError = detail.error;
+    await updateRequest(db, this.requestStoreName, request);
+
+    setTimeout(() => {
+      if (this.isOnline()) {
+        void this.processQueue();
+      }
+    }, nextDelay);
+  }
+
+  private async handlePermanentFailure(db: OfflineHttpDatabase, request: StoredRequest, error: Error): Promise<void> {
+    request.state = 'failed';
+    request.lastError = error.message;
+    request.updatedAt = Date.now();
+    await updateRequest(db, this.requestStoreName, request);
+    const detail = toErrorDetail(request, error, false);
+    const record = this.events.emit('sync:failed', detail);
+    await saveEvent(db, this.eventStoreName, record);
+  }
+
+  private isOnline(): boolean {
+    if (typeof navigator === 'undefined' || typeof navigator.onLine === 'undefined') {
+      return true;
+    }
+    return navigator.onLine;
+  }
+
+}
+
+function buildFetchInit(request: StoredRequest, signal?: AbortSignal): RequestInit {
+  const headers = new Headers(request.headers);
+  applyDefaultContentType(headers, request.body);
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+  };
+  const body = deserializeBody(request.body);
+  if (body !== undefined) {
+    init.body = body;
+  }
+  if (signal) {
+    init.signal = signal;
+  }
+  return init;
+}
+
+async function parseResponse<T>(response: Response, responseType: ResponseType): Promise<T> {
+  switch (responseType) {
+    case 'json':
+      return (await response.json()) as T;
+    case 'text':
+      return (await response.text()) as T;
+    case 'blob':
+      return (await response.blob()) as T;
+    case 'arrayBuffer':
+      return (await response.arrayBuffer()) as T;
+    case 'response':
+    default:
+      return response as unknown as T;
+  }
+}
+
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+function applyDefaultContentType(headers: Headers, body?: SerializedBody | BodyInit | null): void {
+  if (!body) {
+    return;
+  }
+
+  const headerKeys = Array.from(headers.keys());
+  const hasContentType = headerKeys.some((key) => key.toLowerCase() === 'content-type');
+  if (hasContentType) {
+    return;
+  }
+
+  if (isSerializedBody(body)) {
+    switch (body.type) {
+      case 'json':
+        headers.set('Content-Type', 'application/json;charset=UTF-8');
+        break;
+      case 'text':
+        headers.set('Content-Type', 'text/plain;charset=UTF-8');
+        break;
+      case 'searchParams':
+        headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
+        break;
+      case 'blob':
+        headers.set('Content-Type', body.value.type || 'application/octet-stream');
+        break;
+      case 'arrayBuffer':
+        headers.set('Content-Type', 'application/octet-stream');
+        break;
+      case 'formData':
+        // Let the browser set multipart boundaries automatically.
+        break;
+      default:
+        break;
+    }
+    return;
+  }
+
+  if (typeof body === 'string') {
+    headers.set('Content-Type', 'text/plain;charset=UTF-8');
+  } else if (body instanceof URLSearchParams) {
+    headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
+  } else if (body instanceof Blob && !(body instanceof FormData)) {
+    headers.set('Content-Type', body.type || 'application/octet-stream');
+  }
+}
+
+function toErrorDetail(request: StoredRequest, error: unknown, willRetry: boolean): SyncErrorEventDetail {
+  return {
+    id: request.id,
+    url: request.url,
+    method: request.method,
+    attempts: request.attempts,
+    error: error instanceof Error ? error.message : String(error),
+    willRetry,
+    ...(request.metadata ? { metadata: request.metadata } : {}),
+  };
+}
+
+function computeRetryDelay(request: StoredRequest): number {
+  const base = request.retryDelay;
+  const attempt = request.attempts;
+  switch (request.retryStrategy) {
+    case 'fixed':
+      return base;
+    case 'linear':
+      return base * attempt;
+    case 'exponential':
+    default:
+      return base * Math.pow(2, attempt - 1);
+  }
+}
+
+function isSerializedBody(value: unknown): value is SerializedBody {
+  return typeof value === 'object' && value !== null && 'type' in (value as Record<string, unknown>);
+}

--- a/offline-http-client/src/index.ts
+++ b/offline-http-client/src/index.ts
@@ -1,0 +1,5 @@
+export * from './observable.js';
+export * from './events.js';
+export * from './types.js';
+export { OfflineHttpClient } from './httpClient.js';
+export { serializeBody, deserializeBody } from './serialization.js';

--- a/offline-http-client/src/observable.ts
+++ b/offline-http-client/src/observable.ts
@@ -1,0 +1,106 @@
+export type TeardownLogic = (() => void) | void;
+
+export interface Observer<T> {
+  next(value: T): void;
+  error(err: unknown): void;
+  complete(): void;
+}
+
+export type PartialObserver<T> = Partial<Observer<T>> | ((value: T) => void);
+
+export class Subscription {
+  private closed = false;
+  constructor(private readonly teardown?: () => void) {}
+
+  unsubscribe(): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.teardown) {
+      try {
+        this.teardown();
+      } catch (err) {
+        console.error('Error during subscription teardown', err);
+      }
+    }
+  }
+}
+
+export class Observable<T> {
+  constructor(private readonly producer: (observer: Observer<T>) => TeardownLogic) {}
+
+  subscribe(observer: PartialObserver<T>): Subscription {
+    const sink: Observer<T> = normalizeObserver(observer);
+    let teardown: TeardownLogic = undefined;
+    let closed = false;
+
+    try {
+      teardown = this.producer({
+        next: (value) => {
+          if (!closed) {
+            sink.next(value);
+          }
+        },
+        error: (err) => {
+          if (!closed) {
+            closed = true;
+            sink.error(err);
+            if (teardown) {
+              executeTeardown(teardown);
+            }
+          }
+        },
+        complete: () => {
+          if (!closed) {
+            closed = true;
+            sink.complete();
+            if (teardown) {
+              executeTeardown(teardown);
+            }
+          }
+        },
+      });
+    } catch (err) {
+      closed = true;
+      sink.error(err);
+    }
+
+    return new Subscription(() => {
+      if (!closed) {
+        closed = true;
+        if (teardown) {
+          executeTeardown(teardown);
+        }
+      }
+    });
+  }
+
+  static of<T>(value: T): Observable<T> {
+    return new Observable<T>((observer) => {
+      observer.next(value);
+      observer.complete();
+    });
+  }
+}
+
+function normalizeObserver<T>(observer: PartialObserver<T>): Observer<T> {
+  if (typeof observer === 'function') {
+    return {
+      next: observer,
+      error: (err: unknown) => console.error('Unhandled observable error', err),
+      complete: () => undefined,
+    };
+  }
+
+  return {
+    next: observer.next?.bind(observer) ?? (() => undefined),
+    error:
+      observer.error?.bind(observer) ?? ((err: unknown) => console.error('Unhandled observable error', err)),
+    complete: observer.complete?.bind(observer) ?? (() => undefined),
+  };
+}
+
+function executeTeardown(teardown: TeardownLogic): void {
+  if (typeof teardown === 'function') {
+    teardown();
+  }
+}

--- a/offline-http-client/src/serialization.ts
+++ b/offline-http-client/src/serialization.ts
@@ -1,0 +1,119 @@
+import type {
+  SerializedArrayBufferBody,
+  SerializedBlobBody,
+  SerializedBody,
+  SerializedFormDataBody,
+  SerializedFormDataEntryBlob,
+  SerializedFormDataEntryText,
+  SerializedJsonBody,
+  SerializedTextBody,
+  SerializedUrlSearchParamsBody,
+} from './types.js';
+
+export function serializeBody(body: BodyInit | Record<string, unknown> | null | undefined): SerializedBody | undefined {
+  if (body == null) {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return { type: 'text', value: body } satisfies SerializedTextBody;
+  }
+
+  if (body instanceof Blob) {
+    const blobBody: SerializedBlobBody = {
+      type: 'blob',
+      value: body,
+    };
+    if (typeof (body as File).name === 'string' && (body as File).name) {
+      blobBody.fileName = (body as File).name;
+    }
+    return blobBody;
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return { type: 'arrayBuffer', value: body } satisfies SerializedArrayBufferBody;
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    const view = body as ArrayBufferView;
+    const copy = view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
+    return { type: 'arrayBuffer', value: copy } satisfies SerializedArrayBufferBody;
+  }
+
+  if (body instanceof URLSearchParams) {
+    return { type: 'searchParams', value: body.toString() } satisfies SerializedUrlSearchParamsBody;
+  }
+
+  if (body instanceof FormData) {
+    const entries: Array<SerializedFormDataEntryText | SerializedFormDataEntryBlob> = [];
+    for (const [key, value] of body.entries()) {
+      if (typeof value === 'string') {
+        entries.push({ key, valueType: 'text', value });
+      } else {
+        const entry: SerializedFormDataEntryBlob = {
+          key,
+          valueType: 'blob',
+          value,
+        };
+        if (value.name) {
+          entry.fileName = value.name;
+        }
+        entries.push(entry);
+      }
+    }
+    return { type: 'formData', entries } satisfies SerializedFormDataBody;
+  }
+
+  if (typeof body === 'object') {
+    return { type: 'json', value: body } satisfies SerializedJsonBody;
+  }
+
+  throw new Error('Unsupported body type for serialization');
+}
+
+export function deserializeBody(serialized?: SerializedBody): BodyInit | undefined {
+  if (!serialized) {
+    return undefined;
+  }
+
+  switch (serialized.type) {
+    case 'text':
+      return serialized.value;
+    case 'json':
+      return JSON.stringify(serialized.value);
+    case 'blob':
+      if (serialized.fileName) {
+        return recreateFile({
+          key: '',
+          valueType: 'blob',
+          value: serialized.value,
+          fileName: serialized.fileName,
+        });
+      }
+      return serialized.value;
+    case 'arrayBuffer':
+      return serialized.value;
+    case 'searchParams':
+      return serialized.value;
+    case 'formData': {
+      const form = new FormData();
+      for (const entry of serialized.entries) {
+        if (entry.valueType === 'text') {
+          form.append(entry.key, entry.value);
+        } else {
+          form.append(entry.key, recreateFile(entry));
+        }
+      }
+      return form;
+    }
+    default:
+      return undefined;
+  }
+}
+
+function recreateFile(entry: SerializedFormDataEntryBlob): Blob {
+  if (entry.fileName && typeof File !== 'undefined') {
+    return new File([entry.value], entry.fileName, { type: entry.value.type });
+  }
+  return new Blob([entry.value], { type: entry.value.type });
+}

--- a/offline-http-client/src/storage.ts
+++ b/offline-http-client/src/storage.ts
@@ -1,0 +1,124 @@
+import { openDB } from 'idb';
+import type { IDBPDatabase } from 'idb';
+import type { StoredRequest, SyncEventRecord } from './types.js';
+
+export type OfflineHttpDatabase = IDBPDatabase;
+
+export interface DatabaseOptions {
+  databaseName?: string;
+  storeName?: string;
+  eventStoreName?: string;
+}
+
+const DEFAULT_DB_NAME = 'offline-http-client';
+const DEFAULT_REQUEST_STORE = 'requests';
+const DEFAULT_EVENT_STORE = 'events';
+
+export async function initDatabase(options: DatabaseOptions = {}): Promise<OfflineHttpDatabase> {
+  const databaseName = options.databaseName ?? DEFAULT_DB_NAME;
+  const requestStoreName = options.storeName ?? DEFAULT_REQUEST_STORE;
+  const eventStoreName = options.eventStoreName ?? DEFAULT_EVENT_STORE;
+
+  return openDB(databaseName, 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(requestStoreName)) {
+        const store = db.createObjectStore(requestStoreName, {
+          keyPath: 'id',
+        });
+        store.createIndex('by-state', 'state');
+        store.createIndex('by-updatedAt', 'updatedAt');
+      }
+      if (!db.objectStoreNames.contains(eventStoreName)) {
+        const store = db.createObjectStore(eventStoreName, {
+          keyPath: 'id',
+        });
+        store.createIndex('by-timestamp', 'timestamp');
+      }
+    },
+  });
+}
+
+export async function saveRequest(db: OfflineHttpDatabase, storeName: string, request: StoredRequest): Promise<void> {
+  await db.put(storeName, request);
+}
+
+export async function getRequest(db: OfflineHttpDatabase, storeName: string, id: string): Promise<StoredRequest | undefined> {
+  return db.get(storeName, id);
+}
+
+export async function deleteRequest(db: OfflineHttpDatabase, storeName: string, id: string): Promise<void> {
+  await db.delete(storeName, id);
+}
+
+export async function listRequests(db: OfflineHttpDatabase, storeName: string): Promise<StoredRequest[]> {
+  return db.getAll(storeName);
+}
+
+export async function listRequestsByState(
+  db: OfflineHttpDatabase,
+  storeName: string,
+  state: StoredRequest['state'],
+): Promise<StoredRequest[]> {
+  return db.getAllFromIndex(storeName, 'by-state', state);
+}
+
+export async function updateRequest(db: OfflineHttpDatabase, storeName: string, request: StoredRequest): Promise<void> {
+  await db.put(storeName, request);
+}
+
+export async function saveEvent(db: OfflineHttpDatabase, eventStoreName: string, record: SyncEventRecord): Promise<void> {
+  await db.put(eventStoreName, record);
+}
+
+export async function getEventLog(db: OfflineHttpDatabase, eventStoreName: string, since?: number): Promise<SyncEventRecord[]> {
+  if (typeof since === 'number') {
+    const tx = db.transaction(eventStoreName, 'readonly');
+    const index = tx.store.index('by-timestamp');
+    const range = IDBKeyRange.lowerBound(since, true);
+    const events: SyncEventRecord[] = [];
+    let cursor = await index.openCursor(range);
+    while (cursor) {
+      events.push(cursor.value);
+      cursor = await cursor.continue();
+    }
+    await tx.done;
+    return events;
+  }
+  return db.getAll(eventStoreName);
+}
+
+export async function pruneEvents(db: OfflineHttpDatabase, eventStoreName: string, retainMs: number): Promise<void> {
+  const cutoff = Date.now() - retainMs;
+  const tx = db.transaction(eventStoreName, 'readwrite');
+  const index = tx.store.index('by-timestamp');
+  let cursor = await index.openCursor();
+  while (cursor) {
+    if (cursor.value.timestamp < cutoff) {
+      await cursor.delete();
+    }
+    cursor = await cursor.continue();
+  }
+  await tx.done;
+}
+
+export async function clearDatabase(db: OfflineHttpDatabase, storeName: string): Promise<void> {
+  await db.clear(storeName);
+}
+
+export async function migrateFailedToPending(
+  db: OfflineHttpDatabase,
+  storeName: string,
+  ids: string[],
+): Promise<void> {
+  const tx = db.transaction(storeName, 'readwrite');
+  for (const id of ids) {
+    const value = await tx.store.get(id);
+    if (!value) continue;
+    value.state = 'pending';
+    value.attempts = 0;
+    value.updatedAt = Date.now();
+    value.lastError = undefined;
+    await tx.store.put(value);
+  }
+  await tx.done;
+}

--- a/offline-http-client/src/types.ts
+++ b/offline-http-client/src/types.ts
@@ -1,0 +1,182 @@
+export type HttpMethod =
+  | 'GET'
+  | 'POST'
+  | 'PUT'
+  | 'PATCH'
+  | 'DELETE'
+  | 'HEAD'
+  | 'OPTIONS'
+  | 'TRACE'
+  | 'CONNECT'
+  | (string & {});
+
+export type ResponseType = 'json' | 'text' | 'blob' | 'arrayBuffer' | 'response';
+
+export interface HttpRequestOptions<TBody = any> {
+  headers?: HeadersInit;
+  body?: BodyInit | TBody | null;
+  responseType?: ResponseType;
+  retries?: number;
+  retryDelay?: number;
+  retryStrategy?: 'exponential' | 'linear' | 'fixed';
+  queueOnly?: boolean;
+  metadata?: Record<string, unknown>;
+  signal?: AbortSignal;
+}
+
+export interface HttpQueuedResult {
+  status: 'queued';
+  id: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface HttpSuccessResult<T = unknown> {
+  status: 'success';
+  response: Response;
+  data: T;
+}
+
+export type HttpResult<T = unknown> = HttpQueuedResult | HttpSuccessResult<T>;
+
+export interface OfflineHttpClientOptions {
+  databaseName?: string;
+  storeName?: string;
+  eventStoreName?: string;
+  defaultRetries?: number;
+  defaultRetryDelay?: number;
+  autoStart?: boolean;
+  queueRetentionMs?: number;
+}
+
+export interface SerializedJsonBody {
+  type: 'json';
+  value: unknown;
+}
+
+export interface SerializedTextBody {
+  type: 'text';
+  value: string;
+}
+
+export interface SerializedBlobBody {
+  type: 'blob';
+  value: Blob;
+  fileName?: string;
+}
+
+export interface SerializedArrayBufferBody {
+  type: 'arrayBuffer';
+  value: ArrayBuffer;
+}
+
+export interface SerializedFormDataEntryText {
+  key: string;
+  valueType: 'text';
+  value: string;
+}
+
+export interface SerializedFormDataEntryBlob {
+  key: string;
+  valueType: 'blob';
+  value: Blob;
+  fileName?: string;
+}
+
+export interface SerializedFormDataBody {
+  type: 'formData';
+  entries: Array<SerializedFormDataEntryText | SerializedFormDataEntryBlob>;
+}
+
+export interface SerializedUrlSearchParamsBody {
+  type: 'searchParams';
+  value: string;
+}
+
+export type SerializedBody =
+  | SerializedJsonBody
+  | SerializedTextBody
+  | SerializedBlobBody
+  | SerializedArrayBufferBody
+  | SerializedFormDataBody
+  | SerializedUrlSearchParamsBody;
+
+export interface StoredRequest {
+  id: string;
+  method: HttpMethod;
+  url: string;
+  headers?: [string, string][];
+  body?: SerializedBody;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  updatedAt: number;
+  attempts: number;
+  maxAttempts: number;
+  retryDelay: number;
+  retryStrategy: 'exponential' | 'linear' | 'fixed';
+  responseType: ResponseType;
+  state: 'pending' | 'processing' | 'failed';
+  lastError?: string;
+}
+
+export interface SyncSuccessEventDetail<T = unknown> {
+  id: string;
+  url: string;
+  method: HttpMethod;
+  response: {
+    status: number;
+    ok: boolean;
+    headers: [string, string][];
+    data: T;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+export interface SyncErrorEventDetail {
+  id: string;
+  url: string;
+  method: HttpMethod;
+  attempts: number;
+  error: string;
+  willRetry: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SyncRetryEventDetail {
+  id: string;
+  url: string;
+  method: HttpMethod;
+  attempt: number;
+  nextRetryInMs: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SyncQueueEventDetail {
+  id: string;
+  url: string;
+  method: HttpMethod;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SyncDrainEventDetail {
+  remaining: number;
+}
+
+export interface SyncEventMap {
+  'queue:added': SyncQueueEventDetail;
+  'queue:drain': SyncDrainEventDetail;
+  'sync:success': SyncSuccessEventDetail;
+  'sync:error': SyncErrorEventDetail;
+  'sync:retry': SyncRetryEventDetail;
+  'sync:failed': SyncErrorEventDetail;
+}
+
+export type SyncEventType = keyof SyncEventMap;
+
+export interface SyncEventRecord<T extends SyncEventType = SyncEventType> {
+  id: string;
+  type: T;
+  detail: SyncEventMap[T];
+  timestamp: number;
+}
+
+export interface OfflineHttpDB extends IDBDatabase {}

--- a/offline-http-client/tsconfig.json
+++ b/offline-http-client/tsconfig.json
@@ -1,0 +1,49 @@
+{
+  // Visit https://aka.ms/tsconfig to read more about this file
+  "compilerOptions": {
+    // File Layout
+    "rootDir": "src",
+    "outDir": "dist",
+
+    // Environment Settings
+    // See also https://aka.ms/tsconfig/module
+    "module": "es2020",
+    "target": "es2020",
+    "types": [],
+    "lib": ["es2020", "dom", "dom.iterable"],
+    // For nodejs:
+    // "lib": ["esnext"],
+    // "types": ["node"],
+    // and npm install -D @types/node
+
+    // Other Outputs
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    // Stricter Typechecking Options
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    // Style Options
+    // "noImplicitReturns": true,
+    // "noImplicitOverride": true,
+    // "noUnusedLocals": true,
+    // "noUnusedParameters": true,
+    // "noFallthroughCasesInSwitch": true,
+    // "noPropertyAccessFromIndexSignature": true,
+
+    // Recommended Options
+    "strict": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+
+    "moduleResolution": "node10",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a standalone `offline-http-client` npm package for observable-style HTTP helpers with IndexedDB-backed offline queuing and sync events
- implement serialization, storage, and event bus utilities to persist requests, replay them with retries, and surface lifecycle events for recovery
- document usage and architecture with a comprehensive README and mermaid diagrams outlining component interactions and offline/online flows

## Testing
- `cd offline-http-client && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cddd1ac72c832d8f9ebb61c469f7fb