### PR TITLE
Add offline-first HTTP helper project

### DIFF
--- a/offline-http-helpers/.gitignore
+++ b/offline-http-helpers/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+/dist
+
+# Editor artifacts
+*.log
+.DS_Store

--- a/offline-http-helpers/README.md
+++ b/offline-http-helpers/README.md
@@ -1,0 +1,152 @@
+# Offline HTTP Helpers
+
+An offline-first HTTP helper toolkit that delivers RxJS-inspired streams for request lifecycles, persists work in IndexedDB, and automatically replays queued operations once a connection is restored.
+
+## Key features
+
+- **Observable-style APIs** – Every helper returns an `HttpStream` that mimics RxJS semantics with `subscribe`, `pipe`, `map`, and `tap` operators.
+- **Offline-aware queuing** – Requests issued while offline are serialized and persisted in IndexedDB. The helpers replay them when the device regains connectivity.
+- **Durable sync loop** – A `SyncCoordinator` drains the queue, retries with configurable back-off, and emits lifecycle events that remain available after the app restarts.
+- **Universal payload support** – JSON payloads, `FormData`, `Blob`/`File`, `ArrayBuffer`, and `URLSearchParams` bodies are preserved across sessions. Files are kept as binary blobs so uploads survive restarts.
+- **Event-driven error reporting** – Consumers subscribe to strongly-typed events instead of ephemeral callbacks. Errors expose whether they will be retried so UI layers can react or prompt for manual recovery.
+- **Manual controls** – Inspect, retry, or drop queued work programmatically for custom recovery flows.
+
+## Installation
+
+```bash
+npm install offline-http-helpers
+```
+
+Build the project locally:
+
+```bash
+npm install
+npm run build
+```
+
+The compiled artifacts live under `dist/` (both ESM and CJS modules plus type definitions).
+
+## Quick start
+
+```ts
+import { OfflineHttpClient } from 'offline-http-helpers';
+
+const client = new OfflineHttpClient({
+  dbName: 'fieldwork-sync',
+  retryDelays: [1000, 5000, 15000],
+});
+
+// Listen to durable events (survive app restarts once the queue replays)
+const stop = client.events.on('request:sync-error', (event) => {
+  const { request, error, willRetry } = event.detail;
+  console.warn('Sync failed', request.id, error.message, { willRetry });
+});
+
+// Issue a request just like an RxJS Observable
+client
+  .post('https://api.example.com/report', {
+    body: { completedAt: new Date().toISOString(), notes: 'Worked offline all day' },
+  })
+  .subscribe({
+    next: (event) => {
+      if (event.type === 'scheduled') {
+        console.log('Queued offline', event.requestId);
+      }
+      if (event.type === 'response') {
+        console.log('Immediate response', event.data);
+      }
+    },
+    error: (event) => {
+      console.error('Fatal error', event.error);
+    },
+    complete: () => console.log('Stream closed'),
+  });
+```
+
+## Lifecycle events
+
+The `HttpEventHub` emits events on `client.events` and through the exposed `EventTarget`. Every event detail is structured for resilience across app restarts.
+
+| Event | Detail | Purpose |
+| --- | --- | --- |
+| `request:queued` | `{ request }` | Fired when a request is captured while offline. |
+| `request:requeued` | `{ request }` | A request was queued after a failure while online or manually retried. |
+| `request:sync-started` | `{ request, attempt }` | A sync cycle picked up a pending request. |
+| `request:sync-success` | `{ request, response, data }` | Replay succeeded with the parsed payload. |
+| `request:sync-error` | `{ request, error, attempt, willRetry }` | Sync failed. `willRetry` flags automatic retry. |
+| `request:failed` | `{ request, error }` | Automatic retries were exhausted. Manual recovery is required. |
+| `sync:drain-started` | `{ pending }` | Sync loop started draining the queue. |
+| `sync:drain-complete` | `{ pending }` | Sync loop completed (some items may remain if they failed). |
+
+Consumers can subscribe via:
+
+```ts
+const unsubscribe = client.events.on('request:failed', (event) => {
+  // Show a banner, prompt the user, etc.
+});
+```
+
+## Recovering from sync failures
+
+1. Listen to `request:failed` and surface actionable UI to the worker.
+2. Inspect queued items with `await client.listQueued()`.
+3. Decide whether to retry (`client.retry(id)`), modify, or drop (`client.remove(id)`).
+4. Optionally store domain-specific recovery metadata in `metadata` when the request is first made.
+
+## Handling binary uploads
+
+The helper persists binary payloads (files, blobs, `FormData`) directly inside IndexedDB. When replaying, the original MIME type, filename, and modification timestamps are restored. That means workers can capture photos or signatures offline, close the app, and have the helper upload them automatically the next time a connection is available.
+
+## Custom response parsing
+
+When replaying, the helper can only rely on metadata stored with the request. Register reusable parsers and refer to them by key:
+
+```ts
+client.registerParser('reportSummary', async (response) => {
+  const data = await response.json();
+  return { id: data.id, status: data.status };
+});
+
+client.post('https://api.example.com/report', {
+  body: reportPayload,
+  responseParserKey: 'reportSummary',
+});
+```
+
+For ad-hoc immediate requests, you can still pass `parseResponse` (runs immediately when the response returns) but the parser cannot be persisted across app restarts. Prefer the named parser approach for anything that should survive replaying.
+
+## Streaming operators
+
+`HttpStream` instances offer lightweight RxJS-style operators:
+
+```ts
+client
+  .post('/endpoint', { body: payload })
+  .map((event) => ({ ...event, timestamp: Date.now() }))
+  .tap((event) => console.log(event))
+  .subscribe(...);
+```
+
+The stream completes after emitting `scheduled`, `response`, or `retry` events. If you need multi-phase updates for UI, combine helper streams with the global event hub.
+
+## Manual queue management
+
+```ts
+// Inspect
+const metrics = await client.metrics();
+console.log(metrics.pendingRequests.length, 'requests queued');
+
+// Remove
+await client.remove(requestId);
+
+// Retry immediately
+await client.retry(requestId);
+```
+
+## Architecture
+
+Detailed diagrams live in [`docs/architecture.md`](docs/architecture.md). They explain how the queue, event hub, dispatcher, and sync coordinator work together in both online and offline scenarios.
+
+## Testing & checks
+
+This package ships with TypeScript definitions and a `tsup` build pipeline. Run `npm run check` to type-check without emitting artifacts.

--- a/offline-http-helpers/docs/architecture.md
+++ b/offline-http-helpers/docs/architecture.md
@@ -1,0 +1,131 @@
+# Architecture
+
+This document describes how the offline HTTP helpers persist work while offline and replay it safely once a connection is restored.
+
+## Component view
+
+```mermaid
+graph TD
+  subgraph App
+    UI[Mobile UI]
+    Service[Domain Service]
+  end
+
+  subgraph Library
+    Client[OfflineHttpClient]
+    Stream[HttpStream]
+    Events[HttpEventHub]
+    Queue[OfflineRequestQueue]
+    Sync[SyncCoordinator]
+    Dispatcher[RequestDispatcher]
+  end
+
+  subgraph Browser
+    DB[(IndexedDB)]
+    Net[(fetch)]
+  end
+
+  UI --> Service
+  Service --> Client
+  Client --> Stream
+  Client --> Events
+  Client --> Queue
+  Queue --> DB
+  Sync --> Queue
+  Sync --> Dispatcher
+  Dispatcher --> Net
+  Sync --> Events
+  Events --> UI
+```
+
+* **OfflineHttpClient** orchestrates stream creation, queueing, and dispatching.
+* **HttpStream** mimics an RxJS observable, emitting `scheduled`, `response`, `retry`, and `error` events.
+* **OfflineRequestQueue** serializes request state (method, headers, payload, metadata) into IndexedDB so it survives restarts.
+* **SyncCoordinator** drains the queue, applies retry/back-off policies, and surfaces lifecycle events.
+* **RequestDispatcher** performs the actual `fetch` call and parses the response according to the stored response type or parser key.
+
+## Offline submission sequence
+
+```mermaid
+sequenceDiagram
+  participant UI as UI Layer
+  participant Client as OfflineHttpClient
+  participant Queue as OfflineRequestQueue
+  participant DB as IndexedDB
+  participant Events as HttpEventHub
+
+  UI->>Client: post('/reports', { body, metadata })
+  Client->>Client: prepareRequest()
+  alt navigator offline
+    Client->>Queue: enqueue(request)
+    Queue->>DB: store(serializedRequest)
+    Queue-->>Client: storedRequest
+    Client->>Events: emit('request:queued')
+    Client-->>UI: HttpStream emits scheduled + completes
+  else Online
+    Client->>Net: fetch(request)
+    Net-->>Client: Response
+    Client-->>UI: HttpStream emits response + completes
+  end
+```
+
+When offline, the stream informs the caller that the work has been scheduled and completes immediately. The durable `request:queued` event lets the app reflect queued work even after a restart.
+
+## Replay and recovery sequence
+
+```mermaid
+sequenceDiagram
+  participant Sync as SyncCoordinator
+  participant Queue as OfflineRequestQueue
+  participant DB as IndexedDB
+  participant Dispatcher as RequestDispatcher
+  participant Events as HttpEventHub
+
+  loop On connectivity
+    Sync->>Queue: list(pending)
+    Queue->>DB: cursor(status=pending)
+    Queue-->>Sync: pendingRequests
+    alt Request succeeds
+      Sync->>Dispatcher: execute(request)
+      Dispatcher->>Net: fetch
+      Net-->>Dispatcher: response
+      Dispatcher-->>Sync: data + response
+      Sync->>Queue: delete(id)
+      Sync->>Events: emit('request:sync-success')
+    else Request fails
+      Sync->>Dispatcher: execute(request)
+      Dispatcher->>Net: fetch
+      Net-->>Dispatcher: error/response >=500
+      Dispatcher-->>Sync: throw error
+      Sync->>Queue: update(status=pending, retries++, lastError)
+      Sync->>Events: emit('request:sync-error', willRetry=true)
+      Note over Sync: Wait based on retryDelays
+      Sync->>Queue: get(id)
+      Queue-->>Sync: request
+      Sync: retry loop
+    end
+  end
+  alt Retries exhausted
+    Sync->>Queue: update(status=failed)
+    Sync->>Events: emit('request:failed', willRetry=false)
+  end
+```
+
+Apps can listen for `request:sync-error` to show progress or for `request:failed` to prompt the worker for manual intervention. Using `client.retry(id)` places the item back into the pending state so the coordinator can attempt it again.
+
+## Data serialization strategies
+
+* **JSON bodies** – Persisted as structured JSON and re-stringified on replay. The helper automatically sets `Content-Type: application/json` when needed.
+* **FormData** – Stored as an array of entries. Binary parts keep their `Blob` representation plus filename metadata, so uploads (photos, signatures) remain intact.
+* **Blob / File / ArrayBuffer** – Stored using the browser's structured clone support and reconstructed during dispatch.
+* **URLSearchParams** – Stored as the encoded query string.
+* **Metadata** – Any JSON-serializable metadata rides alongside the request so the UI can contextualize sync progress or prompt for recovery actions.
+
+## Error propagation
+
+Errors are surfaced in two ways:
+
+1. **Per-request streams** emit an `error` event only when the helper cannot queue or dispatch the request. Once the work is queued, the stream completes to keep resource usage minimal.
+2. **Event hub events** (`request:sync-error`, `request:failed`) inform the UI about background sync outcomes so it can present durable notifications after the worker reopens the app.
+
+This separation keeps per-call code simple while enabling robust UX patterns for the offline/online transition.

--- a/offline-http-helpers/package-lock.json
+++ b/offline-http-helpers/package-lock.json
@@ -1,0 +1,2037 @@
+{
+  "name": "offline-http-helpers",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "offline-http-helpers",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "idb": "^8.0.3",
+        "nanoid": "^5.1.5"
+      },
+      "devDependencies": {
+        "@types/node": "^24.5.2",
+        "tsup": "^8.5.0",
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.0.tgz",
+      "integrity": "sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.0.tgz",
+      "integrity": "sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.0.tgz",
+      "integrity": "sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.0.tgz",
+      "integrity": "sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.0.tgz",
+      "integrity": "sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.0.tgz",
+      "integrity": "sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.0.tgz",
+      "integrity": "sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.0.tgz",
+      "integrity": "sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.0.tgz",
+      "integrity": "sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.0.tgz",
+      "integrity": "sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.0.tgz",
+      "integrity": "sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.0.tgz",
+      "integrity": "sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.0.tgz",
+      "integrity": "sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.0.tgz",
+      "integrity": "sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.0.tgz",
+      "integrity": "sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.0.tgz",
+      "integrity": "sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.0.tgz",
+      "integrity": "sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.0.tgz",
+      "integrity": "sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.0.tgz",
+      "integrity": "sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.0.tgz",
+      "integrity": "sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.0.tgz",
+      "integrity": "sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.0.tgz",
+      "integrity": "sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.0.tgz",
+      "integrity": "sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.0",
+        "@rollup/rollup-android-arm64": "4.52.0",
+        "@rollup/rollup-darwin-arm64": "4.52.0",
+        "@rollup/rollup-darwin-x64": "4.52.0",
+        "@rollup/rollup-freebsd-arm64": "4.52.0",
+        "@rollup/rollup-freebsd-x64": "4.52.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.0",
+        "@rollup/rollup-linux-arm64-musl": "4.52.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.0",
+        "@rollup/rollup-linux-x64-gnu": "4.52.0",
+        "@rollup/rollup-linux-x64-musl": "4.52.0",
+        "@rollup/rollup-openharmony-arm64": "4.52.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.0",
+        "@rollup/rollup-win32-x64-gnu": "4.52.0",
+        "@rollup/rollup-win32-x64-msvc": "4.52.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.0.tgz",
+      "integrity": "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.25.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "0.8.0-beta.0",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/offline-http-helpers/package.json
+++ b/offline-http-helpers/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "offline-http-helpers",
+  "version": "1.0.0",
+  "description": "Offline-first HTTP helper streams with IndexedDB persistence and replay.",
+  "keywords": [
+    "offline",
+    "http",
+    "indexeddb",
+    "sync",
+    "observable"
+  ],
+  "license": "ISC",
+  "author": "",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "docs"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "check": "tsc --noEmit",
+    "test": "npm run check"
+  },
+  "dependencies": {
+    "idb": "^8.0.3",
+    "nanoid": "^5.1.5"
+  },
+  "devDependencies": {
+    "@types/node": "^24.5.2",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/offline-http-helpers/src/core/eventHub.ts
+++ b/offline-http-helpers/src/core/eventHub.ts
@@ -1,0 +1,68 @@
+import type { HttpEventHubEventMap } from '../types.js';
+
+type Listener<K extends keyof HttpEventHubEventMap> = (
+  event: CustomEvent<HttpEventHubEventMap[K]>
+) => void;
+
+const createCustomEvent = <K extends keyof HttpEventHubEventMap>(
+  type: K,
+  detail: HttpEventHubEventMap[K]
+): CustomEvent<HttpEventHubEventMap[K]> => {
+  if (typeof CustomEvent === 'function') {
+    return new CustomEvent(type, { detail });
+  }
+
+  // Fallback for environments that do not expose CustomEvent (e.g. older Node polyfills).
+  if (typeof document !== 'undefined' && typeof document.createEvent === 'function') {
+    const event = document.createEvent('CustomEvent');
+    event.initCustomEvent(type as string, false, false, detail);
+    return event as CustomEvent<HttpEventHubEventMap[K]>;
+  }
+
+  throw new Error('CustomEvent is not supported in this environment.');
+};
+
+export class HttpEventHub {
+  private readonly target: EventTarget;
+
+  constructor(target?: EventTarget) {
+    this.target = target ?? new EventTarget();
+  }
+
+  emit<K extends keyof HttpEventHubEventMap>(type: K, detail: HttpEventHubEventMap[K]): void {
+    const event = createCustomEvent(type, detail);
+    this.target.dispatchEvent(event);
+  }
+
+  on<K extends keyof HttpEventHubEventMap>(type: K, listener: Listener<K>): () => void {
+    const wrapped: EventListener = (event) => {
+      listener(event as CustomEvent<HttpEventHubEventMap[K]>);
+    };
+
+    this.target.addEventListener(type, wrapped);
+
+    return () => {
+      this.target.removeEventListener(type, wrapped);
+    };
+  }
+
+  once<K extends keyof HttpEventHubEventMap>(type: K, listener: Listener<K>): () => void {
+    const wrapped: EventListener = (event) => {
+      listener(event as CustomEvent<HttpEventHubEventMap[K]>);
+    };
+
+    this.target.addEventListener(type, wrapped, { once: true });
+
+    return () => {
+      this.target.removeEventListener(type, wrapped);
+    };
+  }
+
+  off<K extends keyof HttpEventHubEventMap>(type: K, listener: Listener<K>): void {
+    this.target.removeEventListener(type, listener as unknown as EventListener);
+  }
+
+  asEventTarget(): EventTarget {
+    return this.target;
+  }
+}

--- a/offline-http-helpers/src/core/httpClient.ts
+++ b/offline-http-helpers/src/core/httpClient.ts
@@ -1,0 +1,400 @@
+import { nanoid } from 'nanoid';
+import { HttpEventHub } from './eventHub.js';
+import { HttpStream } from './httpStream.js';
+import { OfflineRequestQueue, type OfflineQueueOptions } from './offlineQueue.js';
+import {
+  HttpRequestError,
+  RequestDispatcher,
+  type ResponseParser,
+} from './requestDispatcher.js';
+import { SyncCoordinator } from './syncCoordinator.js';
+import {
+  type HttpMethod,
+  type HttpRequestConfig,
+  type HttpResponseType,
+  type HttpStreamEvent,
+  type QueueMetrics,
+  type SerializedBody,
+  type SerializedRequestInit,
+  type StoredRequest,
+} from '../types.js';
+import {
+  serializeBody,
+  serializeError,
+  serializeHeaders,
+  serializeRequestInit,
+} from './serialization.js';
+
+interface PreparedRequest<TResponse = unknown> {
+  id: string;
+  method: HttpMethod;
+  url: string;
+  init: RequestInit;
+  body?: BodyInit;
+  serializedInit: SerializedRequestInit;
+  serializedBody?: SerializedBody;
+  metadata?: Record<string, unknown>;
+  responseType: HttpResponseType;
+  responseParserKey?: string;
+  inlineParser?: (response: Response) => Promise<TResponse>;
+  queueWhenOffline: boolean;
+  queueWhenOnlineFails: boolean;
+  maxRetries?: number;
+  retryDelays?: number[];
+  priority: StoredRequest['priority'];
+}
+
+export interface HttpClientOptions extends OfflineQueueOptions {
+  retryDelays?: number[];
+  maxRetries?: number;
+  defaultResponseType?: HttpResponseType;
+  queueWhenOffline?: boolean;
+  queueWhenOnlineFails?: boolean;
+  isOnline?: () => boolean;
+  autoStart?: boolean;
+  responseParsers?: Record<string, ResponseParser>;
+}
+
+const DEFAULT_RETRY_DELAYS = [1000, 3000, 10000, 30000];
+
+export class OfflineHttpClient {
+  readonly events = new HttpEventHub();
+  private readonly queue: OfflineRequestQueue;
+  private readonly dispatcher = new RequestDispatcher();
+  private readonly sync: SyncCoordinator;
+  private readonly parserRegistry = new Map<string, ResponseParser>();
+  private readonly defaults: Required<
+    Pick<
+      HttpClientOptions,
+      'retryDelays' | 'maxRetries' | 'defaultResponseType' | 'queueWhenOffline' | 'queueWhenOnlineFails'
+    >
+  >;
+  private readonly isOnlineFn: () => boolean;
+
+  constructor(private readonly baseOptions: HttpClientOptions = {}) {
+    this.defaults = {
+      retryDelays: baseOptions.retryDelays ?? DEFAULT_RETRY_DELAYS,
+      maxRetries: baseOptions.maxRetries ?? 5,
+      defaultResponseType: baseOptions.defaultResponseType ?? 'json',
+      queueWhenOffline: baseOptions.queueWhenOffline ?? true,
+      queueWhenOnlineFails: baseOptions.queueWhenOnlineFails ?? true,
+    };
+
+    this.isOnlineFn = baseOptions.isOnline ?? (() => (typeof navigator !== 'undefined' ? navigator.onLine : true));
+
+    this.queue = new OfflineRequestQueue({
+      dbName: baseOptions.dbName,
+    });
+
+    if (baseOptions.responseParsers) {
+      for (const [key, parser] of Object.entries(baseOptions.responseParsers)) {
+        this.registerParser(key, parser);
+      }
+    }
+
+    this.sync = new SyncCoordinator(
+      this.queue,
+      this.dispatcher,
+      this.events,
+      (key) => (key ? this.parserRegistry.get(key) : undefined),
+      {
+        retryDelays: this.defaults.retryDelays,
+        isOnline: this.isOnlineFn,
+        autoStart: baseOptions.autoStart,
+      }
+    );
+  }
+
+  get eventTarget(): EventTarget {
+    return this.events.asEventTarget();
+  }
+
+  registerParser(key: string, parser: ResponseParser): void {
+    this.parserRegistry.set(key, parser);
+  }
+
+  unregisterParser(key: string): void {
+    this.parserRegistry.delete(key);
+  }
+
+  async metrics(): Promise<HttpClientMetrics> {
+    const metrics = await this.sync.metrics();
+    const pending = await this.queue.list('pending');
+    return {
+      ...metrics,
+      pendingRequests: pending,
+    };
+  }
+
+  async listQueued(): Promise<StoredRequest[]> {
+    return this.queue.all();
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.queue.delete(id);
+  }
+
+  async retry(id: string): Promise<void> {
+    const request = await this.queue.get(id);
+    if (!request) {
+      return;
+    }
+
+    await this.queue.update(id, { status: 'pending' });
+    this.events.emit('request:requeued', { request });
+    if (this.isOnline()) {
+      void this.sync.drain();
+    }
+  }
+
+  request<TResponse = unknown>(
+    method: HttpMethod,
+    url: string,
+    config: HttpRequestConfig<TResponse> = {}
+  ): HttpStream<HttpStreamEvent<TResponse>> {
+    return new HttpStream<HttpStreamEvent<TResponse>>((observer) => {
+      const abortController = new AbortController();
+      const externalSignal = config.signal;
+      if (externalSignal) {
+        if (externalSignal.aborted) {
+          abortController.abort(externalSignal.reason);
+        } else {
+          externalSignal.addEventListener(
+            'abort',
+            () => abortController.abort(externalSignal.reason),
+            { once: true }
+          );
+        }
+      }
+
+      void this.prepareRequest(method, url, config)
+        .then(async (prepared) => {
+          const isOnline = this.isOnline();
+
+          if (!isOnline && prepared.queueWhenOffline) {
+            const stored = await this.enqueue(prepared, true);
+            observer.next?.({
+              type: 'scheduled',
+              requestId: stored.id,
+              offline: true,
+              queuedAt: stored.createdAt,
+              metadata: stored.metadata,
+            });
+            observer.complete?.();
+            return;
+          }
+
+          try {
+            const parser =
+              prepared.inlineParser ??
+              (prepared.responseParserKey
+                ? (this.parserRegistry.get(prepared.responseParserKey) as
+                    | ResponseParser<TResponse>
+                    | undefined)
+                : undefined);
+
+            const { data, response } = await this.dispatcher.execute<TResponse>({
+              method,
+              url,
+              requestInit: { ...prepared.init, signal: abortController.signal },
+              body: prepared.body,
+              responseType: prepared.responseType,
+              parser,
+            });
+
+            observer.next?.({
+              type: 'response',
+              requestId: prepared.id,
+              response,
+              data,
+            });
+            observer.complete?.();
+          } catch (error) {
+            if (prepared.queueWhenOnlineFails && this.shouldQueueAfterFailure(error)) {
+              const stored = await this.enqueue(prepared, false, error);
+              const delay = this.defaults.retryDelays[0] ?? 0;
+              observer.next?.({
+                type: 'retry',
+                requestId: stored.id,
+                attempt: 1,
+                delay,
+                nextAttemptAt: Date.now() + delay,
+              });
+              observer.complete?.();
+              return;
+            }
+
+            observer.error?.({
+              type: 'error',
+              requestId: prepared.id,
+              error,
+              attempt: 1,
+              retriable: this.shouldQueueAfterFailure(error),
+            });
+          }
+        })
+        .catch((error) => {
+          observer.error?.({
+            type: 'error',
+            requestId: nanoid(),
+            error,
+            attempt: 0,
+            retriable: false,
+          });
+        });
+
+      return () => {
+        abortController.abort();
+      };
+    });
+  }
+
+  get<TResponse = unknown>(url: string, config?: HttpRequestConfig<TResponse>): HttpStream<HttpStreamEvent<TResponse>> {
+    return this.request('GET', url, config);
+  }
+
+  delete<TResponse = unknown>(
+    url: string,
+    config?: HttpRequestConfig<TResponse>
+  ): HttpStream<HttpStreamEvent<TResponse>> {
+    return this.request('DELETE', url, config);
+  }
+
+  head<TResponse = unknown>(url: string, config?: HttpRequestConfig<TResponse>): HttpStream<HttpStreamEvent<TResponse>> {
+    return this.request('HEAD', url, config);
+  }
+
+  options<TResponse = unknown>(
+    url: string,
+    config?: HttpRequestConfig<TResponse>
+  ): HttpStream<HttpStreamEvent<TResponse>> {
+    return this.request('OPTIONS', url, config);
+  }
+
+  post<TResponse = unknown>(
+    url: string,
+    config?: HttpRequestConfig<TResponse>
+  ): HttpStream<HttpStreamEvent<TResponse>> {
+    return this.request('POST', url, config);
+  }
+
+  put<TResponse = unknown>(
+    url: string,
+    config?: HttpRequestConfig<TResponse>
+  ): HttpStream<HttpStreamEvent<TResponse>> {
+    return this.request('PUT', url, config);
+  }
+
+  patch<TResponse = unknown>(
+    url: string,
+    config?: HttpRequestConfig<TResponse>
+  ): HttpStream<HttpStreamEvent<TResponse>> {
+    return this.request('PATCH', url, config);
+  }
+
+  private isOnline(): boolean {
+    return this.isOnlineFn();
+  }
+
+  private shouldQueueAfterFailure(error: unknown): boolean {
+    if (error instanceof HttpRequestError) {
+      return error.response.status >= 500 || error.response.status === 0;
+    }
+
+    if (error instanceof TypeError) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private async prepareRequest<TResponse>(
+    method: HttpMethod,
+    url: string,
+    config: HttpRequestConfig<TResponse>
+  ): Promise<PreparedRequest<TResponse>> {
+    const id = config.requestId ?? nanoid();
+    const headers = new Headers(config.headers ?? {});
+    let body = config.body ?? undefined;
+
+    if (isPlainObject(body)) {
+      headers.set('content-type', headers.get('content-type') ?? 'application/json');
+      body = JSON.stringify(body);
+    }
+
+    const init: RequestInit = {
+      cache: config.cache,
+      credentials: config.credentials,
+      integrity: config.integrity,
+      keepalive: config.keepalive,
+      method,
+      mode: config.mode,
+      redirect: config.redirect,
+      referrer: config.referrer,
+      referrerPolicy: config.referrerPolicy,
+      headers,
+    };
+
+    const serializedHeaders = serializeHeaders(headers);
+    const serializedInit = serializeRequestInit(init, serializedHeaders);
+    const serializedBody = await serializeBody(body as BodyInit | null);
+
+    return {
+      id,
+      method,
+      url,
+      init,
+      body: body as BodyInit | undefined,
+      serializedInit,
+      serializedBody,
+      metadata: config.metadata,
+      responseType: config.responseType ?? this.defaults.defaultResponseType,
+      responseParserKey: config.responseParserKey,
+      inlineParser: config.parseResponse,
+      queueWhenOffline: config.queueWhenOffline ?? this.defaults.queueWhenOffline,
+      queueWhenOnlineFails:
+        config.queueWhenOnlineFails ?? this.defaults.queueWhenOnlineFails,
+      maxRetries: config.maxRetries ?? this.defaults.maxRetries,
+      retryDelays: config.retryDelays ?? this.defaults.retryDelays,
+      priority: config.queuePriority ?? 'normal',
+    };
+  }
+
+  private async enqueue(
+    prepared: PreparedRequest,
+    offline: boolean,
+    error?: unknown
+  ): Promise<StoredRequest> {
+    const stored = await this.queue.enqueue({
+      id: prepared.id,
+      method: prepared.method,
+      url: prepared.url,
+      requestInit: prepared.serializedInit,
+      body: prepared.serializedBody,
+      metadata: prepared.metadata,
+      responseType: prepared.responseType,
+      responseParserKey: prepared.responseParserKey,
+      maxRetries: prepared.maxRetries,
+      retryDelays: prepared.retryDelays,
+      priority: prepared.priority,
+      lastError: error ? serializeError(error) : undefined,
+    });
+
+    this.events.emit(offline ? 'request:queued' : 'request:requeued', { request: stored });
+
+    if (!offline && this.isOnline()) {
+      void this.sync.drain();
+    }
+
+    return stored;
+  }
+}
+
+const plainObjectTag = '[object Object]';
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  Object.prototype.toString.call(value) === plainObjectTag;
+
+export interface HttpClientMetrics extends QueueMetrics {
+  pendingRequests: StoredRequest[];
+}

--- a/offline-http-helpers/src/core/httpStream.ts
+++ b/offline-http-helpers/src/core/httpStream.ts
@@ -1,0 +1,158 @@
+import type { HttpStreamEvent } from '../types.js';
+
+export interface HttpObserver<T> {
+  next?: (value: T) => void;
+  error?: (error: unknown) => void;
+  complete?: () => void;
+}
+
+export type HttpStreamOperator<I, O> = (input: HttpStream<I>) => HttpStream<O>;
+
+type Executor<T> = (observer: HttpObserver<T>) => void | (() => void) | Promise<void | (() => void)>;
+
+export class HttpStream<T> {
+  private readonly executor: Executor<T>;
+
+  constructor(executor: Executor<T>) {
+    this.executor = executor;
+  }
+
+  subscribe(observer: HttpObserver<T>): { unsubscribe: () => void };
+  subscribe(
+    next?: ((value: T) => void) | null,
+    error?: ((error: unknown) => void) | null,
+    complete?: () => void
+  ): { unsubscribe: () => void };
+  subscribe(
+    observerOrNext: HttpObserver<T> | ((value: T) => void) | null = null,
+    error?: ((error: unknown) => void) | null,
+    complete?: () => void
+  ): { unsubscribe: () => void } {
+    const observer: HttpObserver<T> =
+      typeof observerOrNext === 'function'
+        ? { next: observerOrNext ?? undefined, error: error ?? undefined, complete }
+        : observerOrNext ?? { next: undefined, error: undefined, complete: undefined };
+
+    let cleanup: void | (() => void) | Promise<void | (() => void)>;
+    let closed = false;
+
+    const safeObserver: HttpObserver<T> = {
+      next: (value) => {
+        if (!closed) {
+          observer.next?.(value);
+        }
+      },
+      error: (err) => {
+        if (!closed) {
+          closed = true;
+          observer.error?.(err);
+          cleanupIfNeeded(cleanup);
+        }
+      },
+      complete: () => {
+        if (!closed) {
+          closed = true;
+          observer.complete?.();
+          cleanupIfNeeded(cleanup);
+        }
+      },
+    };
+
+    try {
+      cleanup = this.executor(safeObserver);
+    } catch (err) {
+      safeObserver.error?.(err);
+    }
+
+    return {
+      unsubscribe: () => {
+        if (!closed) {
+          closed = true;
+          cleanupIfNeeded(cleanup);
+        }
+      },
+    };
+  }
+
+  pipe(...operators: Array<HttpStreamOperator<unknown, unknown>>): HttpStream<unknown> {
+    return operators.reduce<HttpStream<unknown>>(
+      (stream, operator) => operator(stream),
+      this as unknown as HttpStream<unknown>
+    );
+  }
+
+  map<U>(project: (value: T) => U | Promise<U>): HttpStream<U> {
+    return new HttpStream<U>((observer) => {
+      const subscription = this.subscribe({
+        next: async (value) => {
+          try {
+            const result = await project(value);
+            observer.next?.(result);
+          } catch (error) {
+            observer.error?.(error);
+          }
+        },
+        error: (error) => observer.error?.(error),
+        complete: () => observer.complete?.(),
+      });
+
+      return () => subscription.unsubscribe();
+    });
+  }
+
+  tap(sideEffect: (value: T) => void | Promise<void>): HttpStream<T> {
+    return new HttpStream<T>((observer) => {
+      const subscription = this.subscribe({
+        next: async (value) => {
+          try {
+            await sideEffect(value);
+            observer.next?.(value);
+          } catch (error) {
+            observer.error?.(error);
+          }
+        },
+        error: (error) => observer.error?.(error),
+        complete: () => observer.complete?.(),
+      });
+
+      return () => subscription.unsubscribe();
+    });
+  }
+
+  toPromise(): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      let lastValue: T;
+      this.subscribe({
+        next: (value) => {
+          lastValue = value;
+        },
+        error: reject,
+        complete: () => resolve(lastValue),
+      });
+    });
+  }
+
+  static fromEventStream(event: HttpStreamEvent): HttpStream<HttpStreamEvent> {
+    return new HttpStream<HttpStreamEvent>((observer) => {
+      observer.next?.(event);
+      observer.complete?.();
+    });
+  }
+}
+
+const cleanupIfNeeded = (cleanup: void | (() => void) | Promise<void | (() => void)>): void => {
+  if (!cleanup) {
+    return;
+  }
+
+  if (typeof cleanup === 'function') {
+    cleanup();
+    return;
+  }
+
+  Promise.resolve(cleanup).then((result) => {
+    if (typeof result === 'function') {
+      result();
+    }
+  });
+};

--- a/offline-http-helpers/src/core/offlineQueue.ts
+++ b/offline-http-helpers/src/core/offlineQueue.ts
@@ -1,0 +1,159 @@
+import { openDB, type IDBPDatabase } from 'idb';
+import {
+  type OfflineDbSchema,
+  type OfflineRequestStatus,
+  type QueueMetrics,
+  type SerializedError,
+  type StoredRequest,
+} from '../types.js';
+
+const DEFAULT_DB_NAME = 'offline-http-helpers';
+const DEFAULT_STORE_NAME = 'requests';
+const DB_VERSION = 1;
+
+const priorityRank: Record<StoredRequest['priority'], number> = {
+  high: 0,
+  normal: 1,
+  low: 2,
+};
+
+export interface OfflineQueueOptions {
+  dbName?: string;
+}
+
+export interface QueueInsertPayload
+  extends Omit<
+    StoredRequest,
+    'priorityIndex' | 'createdAt' | 'updatedAt' | 'status' | 'retries' | 'lastError' | 'priority'
+  > {
+  priority?: StoredRequest['priority'];
+  createdAt?: number;
+  updatedAt?: number;
+  status?: OfflineRequestStatus;
+  retries?: number;
+  lastError?: SerializedError;
+}
+
+export class OfflineRequestQueue {
+  private dbPromise?: Promise<IDBPDatabase<OfflineDbSchema>>;
+
+  constructor(private readonly options: OfflineQueueOptions = {}) {}
+
+  private get dbName(): string {
+    return this.options.dbName ?? DEFAULT_DB_NAME;
+  }
+
+  async init(): Promise<void> {
+    await this.getDb();
+  }
+
+  async enqueue(payload: QueueInsertPayload): Promise<StoredRequest> {
+    const now = Date.now();
+    const record: StoredRequest = {
+      ...payload,
+      priorityIndex: priorityRank[payload.priority ?? 'normal'],
+      priority: payload.priority ?? 'normal',
+      createdAt: payload.createdAt ?? now,
+      updatedAt: now,
+      status: payload.status ?? 'pending',
+      retries: payload.retries ?? 0,
+      lastError: payload.lastError,
+    } as StoredRequest;
+
+    const db = await this.getDb();
+    const tx = db.transaction(DEFAULT_STORE_NAME, 'readwrite');
+    await tx.store.put(record);
+    await tx.done;
+    return record;
+  }
+
+  async update(id: string, patch: Partial<StoredRequest>): Promise<StoredRequest | undefined> {
+    const db = await this.getDb();
+    const tx = db.transaction(DEFAULT_STORE_NAME, 'readwrite');
+    const existing = await tx.store.get(id);
+    if (!existing) {
+      await tx.done;
+      return undefined;
+    }
+
+    const updated: StoredRequest = {
+      ...existing,
+      ...patch,
+      priorityIndex: patch.priority ? priorityRank[patch.priority] : existing.priorityIndex,
+      updatedAt: Date.now(),
+    };
+
+    await tx.store.put(updated);
+    await tx.done;
+    return updated;
+  }
+
+  async get(id: string): Promise<StoredRequest | undefined> {
+    const db = await this.getDb();
+    return db.get(DEFAULT_STORE_NAME, id);
+  }
+
+  async delete(id: string): Promise<void> {
+    const db = await this.getDb();
+    await db.delete(DEFAULT_STORE_NAME, id);
+  }
+
+  async list(status: OfflineRequestStatus = 'pending'): Promise<StoredRequest[]> {
+    const db = await this.getDb();
+    const index = db.transaction(DEFAULT_STORE_NAME).store.index('by_status_priority');
+
+    const requests: StoredRequest[] = [];
+    let cursor = await index.openCursor(IDBKeyRange.bound([status, 0], [status, Infinity]));
+
+    while (cursor) {
+      requests.push(cursor.value);
+      cursor = await cursor.continue();
+    }
+
+    return requests;
+  }
+
+  async all(): Promise<StoredRequest[]> {
+    const db = await this.getDb();
+    return db.getAll(DEFAULT_STORE_NAME);
+  }
+
+  async metrics(): Promise<QueueMetrics> {
+    const db = await this.getDb();
+    const store = db.transaction(DEFAULT_STORE_NAME).store;
+    const all = await store.getAll();
+    const pending = all.filter((item) => item.status === 'pending').length;
+    const failed = all.filter((item) => item.status === 'failed').length;
+
+    return {
+      pending,
+      failed,
+    };
+  }
+
+  private async getDb(): Promise<IDBPDatabase<OfflineDbSchema>> {
+    if (!this.dbPromise) {
+      this.dbPromise = openDB<OfflineDbSchema>(this.dbName, DB_VERSION, {
+        upgrade: (db) => {
+          if (!db.objectStoreNames.contains(DEFAULT_STORE_NAME)) {
+            const store = db.createObjectStore(DEFAULT_STORE_NAME, {
+              keyPath: 'id',
+            });
+            store.createIndex('by_status_priority', ['status', 'priorityIndex']);
+          }
+        },
+      });
+    }
+
+    return this.dbPromise;
+  }
+}
+
+export const mapPriorityToIndex = (priority: StoredRequest['priority']): number =>
+  priorityRank[priority];
+
+export const mapIndexToPriority = (index: number): StoredRequest['priority'] => {
+  if (index <= 0) return 'high';
+  if (index === 1) return 'normal';
+  return 'low';
+};

--- a/offline-http-helpers/src/core/requestDispatcher.ts
+++ b/offline-http-helpers/src/core/requestDispatcher.ts
@@ -1,0 +1,78 @@
+import type { HttpResponseType } from '../types.js';
+
+export type ResponseParser<T = unknown> = (response: Response) => Promise<T>;
+
+export interface DispatchRequestOptions<TResponse = unknown> {
+  method: string;
+  url: string;
+  requestInit: RequestInit;
+  body?: BodyInit;
+  responseType: HttpResponseType;
+  parser?: ResponseParser<TResponse>;
+}
+
+export interface DispatchResult<TResponse = unknown> {
+  response: Response;
+  data: TResponse;
+}
+
+export class HttpRequestError<T = unknown> extends Error {
+  readonly response: Response;
+  readonly data: T;
+
+  constructor(message: string, response: Response, data: T) {
+    super(message);
+    this.name = 'HttpRequestError';
+    this.response = response;
+    this.data = data;
+  }
+}
+
+export class RequestDispatcher {
+  async execute<TResponse>({
+    method,
+    url,
+    requestInit,
+    body,
+    responseType,
+    parser,
+  }: DispatchRequestOptions<TResponse>): Promise<DispatchResult<TResponse>> {
+    const init: RequestInit = {
+      ...requestInit,
+      method,
+    };
+
+    if (body !== undefined) {
+      init.body = body;
+    }
+
+    const response = await fetch(url, init);
+    const clone = response.clone();
+
+    const data = parser ? await parser(clone) : await parseResponse<TResponse>(clone, responseType);
+
+    if (!response.ok) {
+      throw new HttpRequestError('Request failed', response, data);
+    }
+
+    return { response, data };
+  }
+}
+
+const parseResponse = async <T>(response: Response, type: HttpResponseType): Promise<T> => {
+  switch (type) {
+    case 'arrayBuffer':
+      return (await response.arrayBuffer()) as unknown as T;
+    case 'blob':
+      return (await response.blob()) as unknown as T;
+    case 'formData':
+      return (await response.formData()) as unknown as T;
+    case 'json':
+      return (await response.json()) as T;
+    case 'text':
+      return (await response.text()) as unknown as T;
+    case 'raw':
+    default:
+      return response as unknown as T;
+  }
+};

--- a/offline-http-helpers/src/core/serialization.ts
+++ b/offline-http-helpers/src/core/serialization.ts
@@ -1,0 +1,207 @@
+import {
+  type ResponseSummary,
+  type SerializedBody,
+  type SerializedError,
+  type SerializedFormDataEntry,
+  type SerializedHeaders,
+  type SerializedRequestInit,
+} from '../types.js';
+
+const plainObjectTag = '[object Object]';
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  Object.prototype.toString.call(value) === plainObjectTag;
+
+export const serializeHeaders = (headers?: HeadersInit): SerializedHeaders => {
+  if (!headers) {
+    return { entries: [] };
+  }
+
+  const headerEntries: Array<[string, string]> = [];
+  const normalized = new Headers(headers);
+  normalized.forEach((value, key) => {
+    headerEntries.push([key, value]);
+  });
+
+  return { entries: headerEntries };
+};
+
+export const deserializeHeaders = (headers: SerializedHeaders): HeadersInit => {
+  return headers.entries;
+};
+
+export const serializeBody = async (body?: BodyInit | null): Promise<SerializedBody | undefined> => {
+  if (body == null) {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return { type: 'text', data: body };
+  }
+
+  if (body instanceof Blob) {
+    return { type: 'blob', data: body, mimeType: body.type };
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return { type: 'arrayBuffer', data: body };
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    return { type: 'arrayBuffer', data: body.buffer.slice(0) };
+  }
+
+  if (body instanceof URLSearchParams) {
+    return { type: 'urlSearchParams', data: body.toString() };
+  }
+
+  if (typeof FormData !== 'undefined' && body instanceof FormData) {
+    const entries: SerializedFormDataEntry[] = [];
+    body.forEach((value, key) => {
+      if (typeof value === 'string') {
+        entries.push({ name: key, valueType: 'string', value });
+        return;
+      }
+
+      const blob = value as File | Blob;
+      entries.push({
+        name: key,
+        valueType: 'blob',
+        value: {
+          blob,
+          filename: 'name' in blob ? blob.name : undefined,
+          lastModified: 'lastModified' in blob ? blob.lastModified : undefined,
+          mimeType: blob.type,
+        },
+      });
+    });
+    return { type: 'formData', data: entries };
+  }
+
+  if (isPlainObject(body)) {
+    return { type: 'json', data: body };
+  }
+
+  throw new Error('Unsupported body type for serialization');
+};
+
+export const deserializeBody = (body?: SerializedBody): BodyInit | undefined => {
+  if (!body) {
+    return undefined;
+  }
+
+  switch (body.type) {
+    case 'text':
+      return body.data;
+    case 'json':
+      return JSON.stringify(body.data);
+    case 'blob':
+      return new Blob([body.data], { type: body.mimeType });
+    case 'arrayBuffer':
+      return body.data;
+    case 'urlSearchParams':
+      return new URLSearchParams(body.data);
+    case 'formData': {
+      const form = new FormData();
+      for (const entry of body.data) {
+        if (entry.valueType === 'string') {
+          form.append(entry.name, entry.value);
+        } else {
+          const { blob, filename, lastModified, mimeType } = entry.value;
+          const fileName = filename ?? 'file';
+          const fileLike =
+            typeof File === 'function'
+              ? new File([blob], fileName, {
+                  type: mimeType ?? blob.type,
+                  lastModified: lastModified ?? Date.now(),
+                })
+              : blob;
+          form.append(entry.name, fileLike, fileName);
+        }
+      }
+      return form;
+    }
+    default:
+      return undefined;
+  }
+};
+
+export const serializeRequestInit = (init: RequestInit, headers: SerializedHeaders): SerializedRequestInit => {
+  return {
+    cache: init.cache,
+    credentials: init.credentials,
+    headers,
+    integrity: init.integrity,
+    keepalive: init.keepalive,
+    method: init.method,
+    mode: init.mode,
+    redirect: init.redirect,
+    referrer: init.referrer,
+    referrerPolicy: init.referrerPolicy,
+    window: init.window,
+  };
+};
+
+export const deserializeRequestInit = (init: SerializedRequestInit): RequestInit => {
+  return {
+    cache: init.cache,
+    credentials: init.credentials,
+    headers: deserializeHeaders(init.headers),
+    integrity: init.integrity,
+    keepalive: init.keepalive,
+    method: init.method,
+    mode: init.mode,
+    redirect: init.redirect,
+    referrer: init.referrer ?? undefined,
+    referrerPolicy: init.referrerPolicy,
+  };
+};
+
+export const serializeError = (error: unknown): SerializedError => {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const response = (error as { response?: Response }).response;
+    if (response) {
+      return {
+        name: error instanceof Error ? error.name : 'HTTPError',
+        message: error instanceof Error ? error.message : `${response.status} ${response.statusText}`,
+        status: response.status,
+        statusText: response.statusText,
+      };
+    }
+  }
+
+  if (error instanceof Response) {
+    return {
+      name: 'HTTPError',
+      message: `${error.status} ${error.statusText}`,
+      status: error.status,
+      statusText: error.statusText,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    message: typeof error === 'string' ? error : 'Unknown error',
+  };
+};
+
+export const summarizeResponse = (response: Response): ResponseSummary => {
+  const headers: Array<[string, string]> = [];
+  response.headers.forEach((value, key) => {
+    headers.push([key, value]);
+  });
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    url: response.url,
+  };
+};

--- a/offline-http-helpers/src/core/syncCoordinator.ts
+++ b/offline-http-helpers/src/core/syncCoordinator.ts
@@ -1,0 +1,215 @@
+import { HttpEventHub } from './eventHub.js';
+import { OfflineRequestQueue } from './offlineQueue.js';
+import { HttpRequestError, RequestDispatcher } from './requestDispatcher.js';
+import { type QueueMetrics, type StoredRequest } from '../types.js';
+import {
+  deserializeBody,
+  deserializeRequestInit,
+  serializeError,
+  summarizeResponse,
+} from './serialization.js';
+
+export interface SyncCoordinatorOptions {
+  retryDelays?: number[];
+  isOnline?: () => boolean;
+  autoStart?: boolean;
+}
+
+const DEFAULT_RETRY_DELAYS = [1000, 3000, 10000, 30000];
+
+export class SyncCoordinator {
+  private readonly retryDelays: number[];
+  private readonly isOnline: () => boolean;
+  private syncing = false;
+  private disposed = false;
+  private listenersAttached = false;
+  private lastSyncAt?: number;
+
+  constructor(
+    private readonly queue: OfflineRequestQueue,
+    private readonly dispatcher: RequestDispatcher,
+    private readonly events: HttpEventHub,
+    private readonly parserResolver: (key?: string) => ((response: Response) => Promise<unknown>) | undefined,
+    options: SyncCoordinatorOptions = {}
+  ) {
+    this.retryDelays = options.retryDelays ?? DEFAULT_RETRY_DELAYS;
+    this.isOnline = options.isOnline ?? (() => (typeof navigator !== 'undefined' ? navigator.onLine : true));
+
+    if (options.autoStart ?? true) {
+      void this.start();
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.listenersAttached) {
+      return;
+    }
+
+    await this.queue.init();
+
+    if (typeof window !== 'undefined' && window.addEventListener) {
+      window.addEventListener('online', this.handleOnline);
+      this.listenersAttached = true;
+    }
+
+    if (this.isOnline()) {
+      void this.drain();
+    }
+  }
+
+  stop(): void {
+    if (this.listenersAttached && typeof window !== 'undefined' && window.removeEventListener) {
+      window.removeEventListener('online', this.handleOnline);
+      this.listenersAttached = false;
+    }
+    this.disposed = true;
+  }
+
+  async drain(): Promise<void> {
+    if (this.syncing || this.disposed || !this.isOnline()) {
+      return;
+    }
+
+    this.syncing = true;
+    try {
+      const pending = await this.queue.list('pending');
+      if (!pending.length) {
+        return;
+      }
+
+      pending.sort((a, b) => a.priorityIndex - b.priorityIndex || a.createdAt - b.createdAt);
+      this.events.emit('sync:drain-started', { pending: pending.length });
+
+      for (const request of pending) {
+        await this.processRequest(request);
+      }
+
+      const remaining = await this.queue.list('pending');
+      this.lastSyncAt = Date.now();
+      this.events.emit('sync:drain-complete', { pending: remaining.length });
+    } finally {
+      this.syncing = false;
+    }
+  }
+
+  async metrics(): Promise<QueueMetrics> {
+    const metrics = await this.queue.metrics();
+    return { ...metrics, lastSyncAt: this.lastSyncAt };
+  }
+
+  private handleOnline = (): void => {
+    if (!this.disposed) {
+      void this.drain();
+    }
+  };
+
+  private async processRequest(request: StoredRequest): Promise<void> {
+    let current: StoredRequest | undefined = request;
+
+    while (current && !this.disposed) {
+      if (!this.isOnline()) {
+        await this.queue.update(current.id, { status: 'pending' });
+        return;
+      }
+
+      const attempt = (current.retries ?? 0) + 1;
+      this.events.emit('request:sync-started', { request: current, attempt });
+      await this.queue.update(current.id, { status: 'in-flight' });
+
+      try {
+        const requestInit = deserializeRequestInit(current.requestInit);
+        const body = deserializeBody(current.body);
+        const parser = this.parserResolver(current.responseParserKey);
+        const { data, response } = await this.dispatcher.execute({
+          method: current.method,
+          url: current.url,
+          requestInit,
+          body,
+          responseType: current.responseType,
+          parser,
+        });
+
+        await this.queue.delete(current.id);
+        const summary = summarizeResponse(response);
+        this.events.emit('request:sync-success', {
+          request: current,
+          response: summary,
+          data,
+        });
+        return;
+      } catch (error) {
+        const serialized = serializeError(error);
+        const shouldRetry = this.shouldRetry(error, current, attempt);
+
+        if (shouldRetry) {
+          const delay = this.getRetryDelay(attempt, current);
+          const updated =
+            (await this.queue.update(current.id, {
+              status: 'pending',
+              retries: attempt,
+              lastError: serialized,
+            })) ?? current;
+
+          this.events.emit('request:sync-error', {
+            request: updated,
+            error: serialized,
+            attempt,
+            willRetry: true,
+          });
+
+          if (delay > 0) {
+            await wait(delay);
+          }
+
+          current = await this.queue.get(current.id);
+          continue;
+        }
+
+        const failed =
+          (await this.queue.update(current.id, {
+            status: 'failed',
+            retries: attempt,
+            lastError: serialized,
+          })) ?? current;
+
+        this.events.emit('request:sync-error', {
+          request: failed,
+          error: serialized,
+          attempt,
+          willRetry: false,
+        });
+        this.events.emit('request:failed', { request: failed, error: serialized });
+        return;
+      }
+    }
+  }
+
+  private shouldRetry(error: unknown, request: StoredRequest, attempt: number): boolean {
+    if (request.maxRetries != null && attempt > request.maxRetries) {
+      return false;
+    }
+
+    if (error instanceof HttpRequestError) {
+      const status = error.response.status;
+      return status >= 500 || status === 0;
+    }
+
+    if (error instanceof TypeError) {
+      // Fetch throws TypeError on network failures.
+      return true;
+    }
+
+    return false;
+  }
+
+  private getRetryDelay(attempt: number, request: StoredRequest): number {
+    const strategy = request.retryDelays ?? this.retryDelays;
+    const index = Math.min(attempt - 1, strategy.length - 1);
+    return strategy[index] ?? 0;
+  }
+}
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });

--- a/offline-http-helpers/src/index.ts
+++ b/offline-http-helpers/src/index.ts
@@ -1,0 +1,23 @@
+export { OfflineHttpClient, type HttpClientOptions, type HttpClientMetrics } from './core/httpClient.js';
+export { HttpStream, type HttpObserver, type HttpStreamOperator } from './core/httpStream.js';
+export { HttpEventHub } from './core/eventHub.js';
+export {
+  HttpRequestError,
+  RequestDispatcher,
+  type ResponseParser,
+  type DispatchRequestOptions,
+  type DispatchResult,
+} from './core/requestDispatcher.js';
+export { SyncCoordinator, type SyncCoordinatorOptions } from './core/syncCoordinator.js';
+export {
+  type HttpMethod,
+  type HttpRequestConfig,
+  type HttpResponseType,
+  type HttpStreamEvent,
+  type OfflineRequestStatus,
+  type StoredRequest,
+  type QueueMetrics,
+  type ResponseSummary,
+  type SyncAttemptResult,
+  type SerializedError,
+} from './types.js';

--- a/offline-http-helpers/src/types.ts
+++ b/offline-http-helpers/src/types.ts
@@ -1,0 +1,186 @@
+import type { DBSchema } from 'idb';
+
+export type HttpMethod =
+  | 'GET'
+  | 'POST'
+  | 'PUT'
+  | 'PATCH'
+  | 'DELETE'
+  | 'HEAD'
+  | 'OPTIONS';
+
+export type HttpResponseType = 'json' | 'text' | 'blob' | 'arrayBuffer' | 'formData' | 'raw';
+
+export interface HttpRequestConfig<TResponse = unknown> extends Omit<RequestInit, 'body' | 'method'> {
+  /** Optional body for the request. */
+  body?: BodyInit | null;
+  /** Arbitrary metadata persisted alongside queued requests. */
+  metadata?: Record<string, unknown>;
+  /** Defaults to true. When true, requests are queued if the device is offline. */
+  queueWhenOffline?: boolean;
+  /**
+   * Defaults to true. When true, requests that fail due to network errors while online
+   * are queued for later replay.
+   */
+  queueWhenOnlineFails?: boolean;
+  /** Maximum number of retry attempts during background replay. */
+  maxRetries?: number;
+  /** Custom delay strategy in milliseconds. */
+  retryDelays?: number[];
+  /**
+   * Determines how the helper resolves the response body. Defaults to `json`.
+   */
+  responseType?: HttpResponseType;
+  /** Custom parser if the consumer needs full control. */
+  parseResponse?: (response: Response) => Promise<TResponse>;
+  /** Identifier of a parser registered on the client. */
+  responseParserKey?: string;
+  /**
+   * Optional override for the generated request id. Useful when the caller wants to de-duplicate.
+   */
+  requestId?: string;
+  /** Prioritise requests during replay. Defaults to `normal`. */
+  queuePriority?: 'high' | 'normal' | 'low';
+}
+
+export type HttpStreamEvent<TData = unknown> =
+  | {
+      type: 'scheduled';
+      requestId: string;
+      offline: boolean;
+      queuedAt: number;
+      metadata?: Record<string, unknown>;
+    }
+  | {
+      type: 'response';
+      requestId: string;
+      response: Response;
+      data: TData;
+    }
+  | {
+      type: 'error';
+      requestId: string;
+      error: unknown;
+      attempt: number;
+      retriable: boolean;
+    }
+  | {
+      type: 'retry';
+      requestId: string;
+      attempt: number;
+      nextAttemptAt: number;
+      delay: number;
+    };
+
+export type OfflineRequestStatus = 'pending' | 'in-flight' | 'failed';
+
+export interface SerializedError {
+  name?: string;
+  message: string;
+  stack?: string;
+  status?: number;
+  statusText?: string;
+  retriable?: boolean;
+}
+
+export interface SerializedHeaders {
+  entries: Array<[string, string]>;
+}
+
+export type SerializedBody =
+  | { type: 'json'; data: unknown }
+  | { type: 'text'; data: string }
+  | { type: 'blob'; data: Blob; mimeType: string }
+  | { type: 'arrayBuffer'; data: ArrayBuffer }
+  | { type: 'formData'; data: SerializedFormDataEntry[] }
+  | { type: 'urlSearchParams'; data: string };
+
+export type SerializedFormDataEntry =
+  | {
+      name: string;
+      valueType: 'string';
+      value: string;
+    }
+  | {
+      name: string;
+      valueType: 'blob';
+      value: {
+        blob: Blob;
+        filename?: string;
+        lastModified?: number;
+        mimeType?: string;
+      };
+    };
+
+export interface SerializedRequestInit extends Omit<RequestInit, 'body' | 'headers' | 'signal'> {
+  headers: SerializedHeaders;
+}
+
+export interface StoredRequest {
+  id: string;
+  method: HttpMethod;
+  url: string;
+  requestInit: SerializedRequestInit;
+  body?: SerializedBody;
+  metadata?: Record<string, unknown>;
+  responseType: HttpResponseType;
+  responseParserKey?: string;
+  createdAt: number;
+  updatedAt: number;
+  retries: number;
+  maxRetries?: number;
+  retryDelays?: number[];
+  priority: 'high' | 'normal' | 'low';
+  priorityIndex: number;
+  status: OfflineRequestStatus;
+  lastError?: SerializedError;
+}
+
+export interface OfflineDbSchema extends DBSchema {
+  requests: {
+    key: string;
+    value: StoredRequest;
+    indexes: {
+      by_status_priority: [OfflineRequestStatus, number];
+    };
+  };
+}
+
+export interface SyncAttemptResult<TData = unknown> {
+  request: StoredRequest;
+  success: boolean;
+  data?: TData;
+  responseSummary?: ResponseSummary;
+  error?: SerializedError;
+  attempt: number;
+  willRetry: boolean;
+}
+
+export interface ResponseSummary {
+  status: number;
+  statusText: string;
+  headers: Array<[string, string]>;
+  url: string;
+}
+
+export interface HttpEventHubEventMap {
+  'request:queued': { request: StoredRequest };
+  'request:requeued': { request: StoredRequest };
+  'request:sync-started': { request: StoredRequest; attempt: number };
+  'request:sync-success': { request: StoredRequest; response: ResponseSummary; data: unknown };
+  'request:sync-error': {
+    request: StoredRequest;
+    error: SerializedError;
+    attempt: number;
+    willRetry: boolean;
+  };
+  'request:failed': { request: StoredRequest; error: SerializedError };
+  'sync:drain-started': { pending: number };
+  'sync:drain-complete': { pending: number };
+}
+
+export interface QueueMetrics {
+  pending: number;
+  failed: number;
+  lastSyncAt?: number;
+}

--- a/offline-http-helpers/tsconfig.json
+++ b/offline-http-helpers/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "esnext",
+    "target": "es2020",
+    "lib": ["ES2020", "DOM"],
+    "types": [],
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
## Summary
- add an `OfflineHttpClient` that wraps fetch calls with observable-style helpers, automatic queuing, and global events for consumers
- persist queued requests in IndexedDB with robust serialization so JSON, blobs, form data, and metadata survive app restarts
- introduce a sync coordinator, documentation, and architecture diagrams that explain background replay, retries, and recovery flows

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cddd1ac72c832d8f9ebb61c469f7fb